### PR TITLE
Fix reading BED file and deleting header row.

### DIFF
--- a/bedshift/bedshift.py
+++ b/bedshift/bedshift.py
@@ -523,7 +523,7 @@ class Bedshift(object):
 
         # if there is a header line in the table, remove it
         if not str(df.iloc[0, 1]).isdigit():
-            df = df[1:]
+            df = df[1:].reset_index(drop=True)
 
         df[3] = "-"  # column indicating which modifications were made
         return df

--- a/bedshift/bedshift.py
+++ b/bedshift/bedshift.py
@@ -176,7 +176,7 @@ class Bedshift(object):
             )
             num_add = dflen
         add_rows = random.sample(list(range(dflen)), num_add)
-        add_df = df.reindex([add_rows]).reset_index(drop=True)
+        add_df = df.loc[add_rows].reset_index(drop=True)
         add_df[3] = pd.Series(["A"] * add_df.shape[0])
         self.bed = self.bed.append(add_df, ignore_index=True)
         return num_add

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,6 +12,7 @@ class TestBedshift(unittest.TestCase):
     def test_read_bed(self):
         reader = bedshift.Bedshift('tests/header_test.bed')
         self.assertTrue(list(reader.bed.columns), [0,1,2,3])
+        self.assertTrue(list(reader.bed.index), [0,1,2])
 
     def test_read_chrom_sizes(self):
         self.bs._read_chromsizes("tests/hg19.chrom.sizes")


### PR DESCRIPTION
Who knew reading a BED file could be so pesky!

In a previous commit, I had to delete the header after reading a BED file because it would cause problems with column names.  But, that left the index as [1,2,3...] missing the 0th element. With the massive amount of samples that you ran in pep_project_5samples, we were able to find that .loc[] from the 0th index would cause the indexing to fail.